### PR TITLE
Cross references from foreign registrations or renewals are suspected foreign

### DIFF
--- a/0-parse-registrations.py
+++ b/0-parse-registrations.py
@@ -87,9 +87,11 @@ class Parser(object):
 
     def process_registration(self, entry, parent=None):
         regnums = entry.attrib.get('regnum', '').split()
+
         uuid = entry.attrib.get('id', None)
         authors = self.xpath(entry, "author/authorName")
-        note = self.xpath1(entry, 'note')
+        notes = self.xpath(entry, 'note')
+        
         reg_date = self.date(entry, "regDate") or self.date(entry, 'regdate')
         title = self.xpath1(entry, "title")
         if len(regnums) == 1:
@@ -122,7 +124,7 @@ class Parser(object):
         #    if subtag.tag not in self.seen:
         #        print(subtag.tag)
         #        self.seen.add(subtag.tag)
-        registration = dict(uuid=uuid, regnum=regnum, regnums=regnums, reg_date=reg_date, title=title, authors=authors, publishers=publishers, extra=extra, note=note)
+        registration = dict(uuid=uuid, regnum=regnum, regnums=regnums, reg_date=reg_date, title=title, authors=authors, publishers=publishers, extra=extra, notes=notes)
 
         if parent:
             registration['parent'] = dict(

--- a/0-parse-registrations.py
+++ b/0-parse-registrations.py
@@ -120,6 +120,9 @@ class Parser(object):
             if tags:
                 extra[name].extend(tags)
 
+        if extra['prevPub'] or extra['prev-regNum']:
+            print extra['prevPub'], extra['prev-regNum']
+                
         #for subtag in entry.xpath("*"):
         #    if subtag.tag not in self.seen:
         #        print(subtag.tag)

--- a/1-parse-renewals.py
+++ b/1-parse-renewals.py
@@ -5,12 +5,14 @@ import json
 from pdb import set_trace
 import os
 from csv import DictReader
+from collections import defaultdict
 
 class Parser(object):
 
     def __init__(self):
         self.count = 0
-
+        self.cross_references = defaultdict(list)
+        
     def process_directory_tree(self, path):
         for i in os.listdir(path):
             if not i.endswith('tsv'):
@@ -42,10 +44,16 @@ class Parser(object):
                     see_also_renewal=see_also_renewal,
                     see_also_registration=see_also_registration,
         )
+        if see_also_registration:
+            self.cross_references[regnum].extend(see_also_registration)
         return data
-
+            
 output = open("output/1-parsed-renewals.ndjson", "w")
-for parsed in Parser().process_directory_tree("renewals/data"):
+parser = Parser()
+for parsed in parser.process_directory_tree("renewals/data"):
         json.dump(parsed, output)
         output.write("\n")
+
+output = open("output/1-renewal-cross-references.json", "w")
+json.dump(parser.cross_references, output)
 

--- a/1-parse-renewals.py
+++ b/1-parse-renewals.py
@@ -35,8 +35,18 @@ class Parser(object):
         renewal_id = entry['id']
         renewal_date = entry.get('dreg', None)
         new_matter = entry['new_matter']
+        see_also_renewal = entry['see_also_ren'].split("|")
+        see_also_registration = entry['see_also_reg'].split("|")
         data = dict(uuid=uuid, regnum=regnum, reg_date=reg_date, renewal_id=renewal_id,
-                    renewal_date=renewal_date, author=author, title=title, new_matter=new_matter)
+                    renewal_date=renewal_date, author=author, title=title, new_matter=new_matter,
+                    see_also_renewal=see_also_renewal,
+                    see_also_registration=see_also_registration,
+        )
+        if see_also_registration:
+            print see_also_registration
+        if see_also_renewal:
+            print see_also_renewal
+
         return data
 
 output = open("output/1-parsed-renewals.ndjson", "w")

--- a/1-parse-renewals.py
+++ b/1-parse-renewals.py
@@ -35,18 +35,13 @@ class Parser(object):
         renewal_id = entry['id']
         renewal_date = entry.get('dreg', None)
         new_matter = entry['new_matter']
-        see_also_renewal = entry['see_also_ren'].split("|")
-        see_also_registration = entry['see_also_reg'].split("|")
+        see_also_renewal = [x for x in entry['see_also_ren'].split("|") if x]
+        see_also_registration = [x for x in entry['see_also_reg'].split("|") if x]
         data = dict(uuid=uuid, regnum=regnum, reg_date=reg_date, renewal_id=renewal_id,
                     renewal_date=renewal_date, author=author, title=title, new_matter=new_matter,
                     see_also_renewal=see_also_renewal,
                     see_also_registration=see_also_registration,
         )
-        if see_also_registration:
-            print see_also_registration
-        if see_also_renewal:
-            print see_also_renewal
-
         return data
 
 output = open("output/1-parsed-renewals.ndjson", "w")

--- a/2-normalize.py
+++ b/2-normalize.py
@@ -20,8 +20,8 @@ class Processor(object):
     FOREIGN_PREFIXES = set(["AF", "AFO", "AF0"])
     INTERIM_PREFIXES = set(["AI", "AIO", "AI0"])
 
-    DATE_AND_NUMBER_XREF = re.compile("([0-9]{,2}[A-Z][a-z]{2}[0-9]{2})[;,] ([A-Z]{1,2}[0-9-]+)")
-    POSSIBLE_NUMBER_XREF = re.compile("([A-Z]{1,2}[0-9-]{4,})")
+    DATE_AND_NUMBER_XREF = re.compile("([0-9]{,2}[A-Z][a-z]{2}[0-9]{2})[;,] (A[A-Z]?[0-9-]+)")
+    POSSIBLE_NUMBER_XREF = re.compile("(A{1,2}[0-9-]{4,})")
     
     # Big foreign publishing cities that are sometimes mentioned
     # without the context of the country.

--- a/3-handle-easy-cases.py
+++ b/3-handle-easy-cases.py
@@ -33,6 +33,18 @@ for i in open("output/2-cross-references-in-foreign-registrations.ndjson"):
     data = json.loads(i)
     foreign_xrefs[data['regnum']].append(data)
 
+    # Create another cross-reference going in the other direction.
+    other_regnum = data['original_registration']['regnum']
+    reverse = dict(
+        note=data['note'],
+        reg_date=data['original_registration']['reg_date'],
+        title=data['original_registration']['title'],
+        original_registration=dict(
+            title=None, regnum=data['regnum']
+        )
+    )
+    foreign_xrefs[other_regnum].append(reverse)
+    
 for i in open("output/1-parsed-renewals.ndjson"):
     data = json.loads(i)
     renewals_by_regnum[data['regnum']].append(data)
@@ -82,7 +94,7 @@ for i in open("output/2-registrations-in-range.ndjson"):
         count_as_foreign = True
         note = xref['note']
         other_regnum = xref['original_registration']['regnum']
-        other_title = xref['original_registration']['title']
+        other_title = xref['original_registration'].get('title')
         warning = "Apparently referenced by a foreign registration (%s, %r), may be a foreign publication. Original note: %r." % (
             other_regnum, other_title, note
         )
@@ -93,12 +105,10 @@ for i in open("output/2-registrations-in-range.ndjson"):
                 "Registration date is a match (%s), this is very likely a foreign publication." % xref['reg_date']
             )
             
-        # Put this in potentially_foreign -- at the least it needs to
-        # be manually checked.
-        registration_output = potentially_foreign
         if data['disposition'] == 'Not renewed.':
             data['disposition'] = 'Not renewed but potentially foreign.'
-        
+            registration_output = potentially_foreign
+            
     data['renewals'] = renewals
     json.dump(data, registration_output)
     registration_output.write("\n")

--- a/3-handle-easy-cases.py
+++ b/3-handle-easy-cases.py
@@ -26,6 +26,13 @@ matched = open("output/3-registrations-with-renewal.ndjson", "w")
 not_matched = open("output/3-registrations-with-no-renewal.ndjson", "w")
 not_yet_matched = open("output/3-registrations-to-check.ndjson", "w")
 
+potentially_foreign = open("output/3-potentially-foreign-registrations.ndjson", "w")
+
+foreign_xrefs = defaultdict(list)
+for i in open("output/2-cross-references-in-foreign-registrations.ndjson"):
+    data = json.loads(i)
+    foreign_xrefs[data['regnum']].append(data)
+
 for i in open("output/1-parsed-renewals.ndjson"):
     data = json.loads(i)
     renewals_by_regnum[data['regnum']].append(data)
@@ -69,6 +76,28 @@ for i in open("output/2-registrations-in-range.ndjson"):
         child['renewals'] = []
         for child_regnum in child['regnums']:
             child['renewals'].extend(renewals_by_regnum[child_regnum])
+
+    is_foreign = foreign_xrefs[num]
+    for xref in is_foreign:
+        count_as_foreign = True
+        note = xref['note']
+        other_regnum = xref['original_registration']['regnum']
+        other_title = xref['original_registration']['title']
+        warning = "Apparently referenced by a foreign registration (%s, %r), may be a foreign publication. Original note: %r." % (
+            other_regnum, other_title, note
+        )
+        data.setdefault('warnings', []).append(warning)
+         
+        if xref['reg_date'] == data['reg_date']:
+            data['warnings'].append(
+                "Registration date is a match (%s), this is very likely a foreign publication." % xref['reg_date']
+            )
+            
+        # Put this in potentially_foreign -- at the least it needs to
+        # be manually checked.
+        registration_output = potentially_foreign
+        if data['disposition'] == 'Not renewed.':
+            data['disposition'] = 'Not renewed but potentially foreign.'
         
     data['renewals'] = renewals
     json.dump(data, registration_output)

--- a/5-sort-it-out.py
+++ b/5-sort-it-out.py
@@ -28,7 +28,7 @@ def destination(disposition):
         return probably_not
     if disposition.startswith("Renewed"):
         return yes
-    if disposition.startswith("Not renewed but potentially foreign"):
+    if disposition.startswith("Potentially foreign"):
         return potentially_foreign
     if disposition.startswith("Not renewed"):
         return no

--- a/5-sort-it-out.py
+++ b/5-sort-it-out.py
@@ -19,6 +19,7 @@ probably = Output("probably-renewed")
 probably_not = Output("probably-not-renewed")
 yes = Output("renewed")
 no = Output("not-renewed")
+potentially_foreign = Output("potentially-foreign")
 
 def destination(disposition):
     if disposition.startswith("Probably renewed"):
@@ -27,12 +28,15 @@ def destination(disposition):
         return probably_not
     if disposition.startswith("Renewed"):
         return yes
+    if disposition.startswith("Not renewed but potentially foreign"):
+        return potentially_foreign
     if disposition.startswith("Not renewed"):
         return no
 
 for file in (
         "3-registrations-with-renewal",
         "3-registrations-with-no-renewal",
+        "3-potentially-foreign-registrations",
         "4-probably-renewed",
         "4-probably-not-renewed",
 ):
@@ -42,7 +46,7 @@ for file in (
         dest = destination(data['disposition'])
         dest.output(i)
 
-outputs = [yes, no, probably, probably_not]
+outputs = [yes, no, probably, probably_not, potentially_foreign]
 total = sum(x.count for x in outputs)
         
 for output in outputs:

--- a/README.md
+++ b/README.md
@@ -59,9 +59,10 @@ The final script's output will look something like this:
 
 ```
 output/FINAL-renewed.ndjson: 159420 (18.83%)
-output/FINAL-not-renewed.ndjson: 623674 (73.68%)
+output/FINAL-not-renewed.ndjson: 623668 (73.68%)
 output/FINAL-probably-renewed.ndjson: 61747 (7.29%)
 output/FINAL-probably-not-renewed.ndjson: 1589 (0.19%)
+output/FINAL-potentially-foreign.ndjson: 6 (0.00%)
 ```
 
 You'll see a number of large files in the `output` directory. These

--- a/README.md
+++ b/README.md
@@ -131,6 +131,10 @@ Outputs:
   of a renewal record could make the difference between still being
   in-copyright and being in the public domain.
 
+* `2-cross-references-in-foreign-registrations` - Contains a few
+  hundred strings that look like references in a foreign copyright
+  registration to another registration. This might indicate that 
+
 * `2-registrations-error.ndjson` - Contains about 20,000
   registrations which can't be processed because they're
   missing essential information. This information might be missing

--- a/README.md
+++ b/README.md
@@ -58,11 +58,10 @@ python 5-sort-it-out.py
 The final script's output will look something like this:
 
 ```
-output/FINAL-renewed.ndjson: 159420 (18.83%)
-output/FINAL-not-renewed.ndjson: 623668 (73.68%)
-output/FINAL-probably-renewed.ndjson: 61747 (7.29%)
-output/FINAL-probably-not-renewed.ndjson: 1589 (0.19%)
-output/FINAL-potentially-foreign.ndjson: 6 (0.00%)
+output/FINAL-renewed.ndjson: 158019 (18.73%)
+output/FINAL-not-renewed.ndjson: 622455 (73.79%)
+output/FINAL-probably-renewed.ndjson: 61494 (7.29%)
+output/FINAL-probably-not-renewed.ndjson: 1578 (0.19%)
 ```
 
 You'll see a number of large files in the `output` directory. These


### PR DESCRIPTION
This branch starts tracking cross-references mentioned in renewals and registrations and parsing them out of the 'notes' field of registrations. When we discover that a registration is a foreign registration, all the other registrations it references (or that referenced it) are treated as potentially foreign.

If a registration looks like a normal, non-renewed, non-foreign registration, but its registration or renewal references (or is referenced by) a registration that turned out to be a foreign registration, it's put into a separate file for manual checking.

Right now the file contains only six works, and they all look like false negatives -- they matched classification strings like `A8219M3` which resemble registration numbers.