### PR TITLE
minor fixes to help new users run these scripts installing from scratch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Identifying Public Domain Works with Python
 
-This set of Python scripts combines [copyright registration
+This set of Python 2 scripts combines [copyright registration
 data](https://github.com/NYPL/catalog_of_copyright_entries_project)
 with [copyright renewal data](https://github.com/NYPL/cce-renewals/)
 to identify works whose copyright has lapsed because a registration
@@ -45,6 +45,8 @@ time.
 git submodule init
 git submodule update
 ```
+
+Note that these scripts require Python 2 (i.e. do not work with Python 3).
 
 Make sure the lxml XML parser is installed:
 

--- a/compare.py
+++ b/compare.py
@@ -9,7 +9,9 @@ class Comparator(object):
         for i in open(renewals_input_path):
             renewal = Renewal(**json.loads(i))
             regnum = renewal.regnum
-            if not isinstance(regnum, list):
+            if regnum is None:
+                regnum = ()
+            elif not isinstance(regnum, list):
                 regnum = [regnum]
             for r in regnum:
                 r = r.replace("-", "")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-dateutil
+python-dateutil
 lxml
 unicodecsv


### PR DESCRIPTION
I was able to get everything running on a Mint 19 install with just a few minor changes:

- it wouldn't run for me on Python 3.7, but fine on Python 2.7.16 (I created a fresh virtualenv), so I added a note about that in the README.

- pip barfed on the dateutil requirement, and according to PiPy the correct package name is python-dateutil, which fixed the pip problem.

- compare.py crashed on a case where the regnum was "null" in the JSON input, so I handled that as just an empty list.